### PR TITLE
컬러함수 리팩토링, 테스트 코드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,58 @@
 # nyang2
 
-JS로 만드는 Bitmap 이미지 에디터 프로젝트 
+TypeScript 만드는 Bitmap 이미지 에디터 프로젝트 
+
+
+# Color 정의 
+
+adobe, rgb, hsl, hsv, lab, xyz, cmyk 의 함수를 지원합니다. 
+
+```js
+rgb(255, 0, 0) => { r: 255, g: 0, b: 0}
+hsl(1, 0, 0) => { h: 1, s: 0, l: 0}
+hsv(1, 0, 0) => { h: 1, s: 0, v: 0}
+lab(100, -100, 127) => { l: 100, a: -100, b: 127}
+```
+
+# Color 파서 
+
+간단한 컬러 문자열을 파싱할 수 있는 함수를 제공합니다. 
+
+```js
+parse('rgb(255, 0, 0)') => rgb(255, 0, 0) => { r: 255, g: 0, b: 0 }
+```
+
+parse 함수에 들어온 문자열은 기본적으로 위에 정의된 Color 정의 함수를 실행하는 구조로 되어 있습니다. 내부적으로 자바스크립트의 동적 함수 정의를 사용하여 구현 되어 있어서 함수 정의만 할 수 있으면 좀 더 쉽게 파서를 구현할 수 있습니다. 
+
+
+# Color 변환 함수 
+
+https://www.easyrgb.com/en/math.php  여기에 있는 공식을 TypeScript 로 변환합니다. 
+
+nyang2는 아래의 컬러 변화 함수를 제공합니다. 
+
+* adobe2xyz
+* cmy2cmyk
+* cmy2rgb
+* cmyk2cmy
+* hsl2rgb
+* hsv2rgb
+* lab2rgb
+* lab2xyz
+* name
+* rgb2cmy
+* rgb2hsl
+* rgb2hsv
+* rgb2lab
+* rgb2xyz
+* xyz2adobe
+* xyz2lab
+* xyz2rgb 
+
 
 # 이미지 편집을 위해서 구현해야할 것들 
-
-* Color 변환 함수 
-  * https://www.easyrgb.com/en/math.php  여기에 있는 공식을 JS 로 변환합니다. 
-  * 변환하기 전에 전체 모듈 사용에 대한 방식이 필요하니 그것 먼저 설정하고 갈게요. 
 * 이미지 Filter 알고리즘 
 * 자체 UI 
-
-# 기술스택 
-
-* Javascript
-* Webpack 빌드 
-* Color 변환 함수는 자체 제작 
-* 필터도 자체 제작 (알고리즘 힌트는 다른 곳에서 얻어올 수 있으려나?) 
-
 
 # 구조 
 ```
@@ -50,4 +86,6 @@ npm install
 npm run build 
 ```
 
+
+# License : MIT 
 

--- a/src/color/cmy2cmyk.ts
+++ b/src/color/cmy2cmyk.ts
@@ -1,18 +1,11 @@
-import { ColorListType, CMY, CMYK } from "../../types";
+import { CMY, CMYK } from "../../types";
 
-export function cmy2cmyk(...arg: ColorListType | [CMY]) : CMYK {
-  let c:number = 0;
-  let m:number = arg[1] || 0;
-  let y:number = arg[2] || 0;
-  let k:number = 1;
-  if (arg.length === 1) {
-    c = arg[0].c;
-    m = arg[0].m;
-    y = arg[0].y;
-  } else {
-    c = arg[0];
-  }
+export function cmy2cmyk(cmy: CMY) : CMYK {
+  let {c, m, y} = cmy; 
+
+  let k:number = 1;  
   k = Math.min(c, m, y, k);
+
   if (k === 1) {
     c = 0;
     m = 0;

--- a/src/color/cmy2rgb.ts
+++ b/src/color/cmy2rgb.ts
@@ -1,16 +1,8 @@
-import { ColorListType, CMY, RGB } from "../../types";
+import { CMY, RGB } from "../../types";
 
-export function cmy2rgb(...arg: ColorListType | [CMY]) : RGB {
-  let c:number = 0;
-  let m:number = arg[1] || 0;
-  let y:number = arg[2] || 0;
-  if (arg.length === 1) {
-    c = arg[0].c;
-    m = arg[0].m;
-    y = arg[0].y;
-  } else {
-    c = arg[0];
-  }
+export function cmy2rgb(cmy: CMY) : RGB {
+  const {c, m, y} = cmy; 
+
   return {
     r: Math.round((1 - Math.max(0, Math.max(c))) * 255),
     g: Math.round((1 - Math.max(0, Math.max(m))) * 255),

--- a/src/color/cmyk2cmy.ts
+++ b/src/color/cmyk2cmy.ts
@@ -1,19 +1,11 @@
-import { CMYKColorListType, CMYK, CMY } from "../../types";
+import { CMYK, CMY } from "../../types";
 
-export function cmyk2cmy(...arg: CMYKColorListType | [CMYK]) : CMY {
-  let c:number = 0;
-  let m:number = arg[1] || 0;
-  let y:number = arg[2] || 0;
-  let k:number = arg[3] || 0;
-  if (arg.length === 1) {
-    c = arg[0].c;
-    m = arg[0].m;
-    y = arg[0].y;
-    k = arg[0].k;
-  } else {
-    c = arg[0];
-  }
+export function cmyk2cmy(cmyk: CMYK) : CMY {
+
+  let { c, m, y, k} = cmyk;
+
   k = Math.max(0, Math.min(1, k));
+
   return {
     c: Math.max(0, Math.min(1, c)) * (1 - k) + k,
     m: Math.max(0, Math.min(1, m)) * (1 - k) + k,

--- a/src/color/hsl2rgb.ts
+++ b/src/color/hsl2rgb.ts
@@ -1,0 +1,34 @@
+import { RGB, HSL } from "../../types";
+import { hue2rgb } from "./hue2rgb";
+
+
+export function hsl2rgb(hsl: HSL): RGB {
+
+  const { h: hue, s, l: lightness} = hsl; 
+  let r = 0, g = 0, b = 0;
+
+  if (s === 0) {      // gray 
+    r = lightness * 255; 
+    g = lightness * 255; 
+    b = lightness * 255; 
+
+    return { r, g, b }
+  } else {
+
+    let v1 = 0, v2 = 0; 
+    if (lightness < 0.5) {
+      v2 = lightness  * ( 1 + s);
+    } else {
+      v2 = (lightness + s ) - (s * lightness);
+    }
+
+    v1 = (2 * lightness) - v2; 
+
+    return {
+      r: Math.round(255 * hue2rgb(v1, v2, hue + (1/3))),
+      g: Math.round(255 * hue2rgb(v1, v2, hue)),
+      b: Math.round(255 * hue2rgb(v1, v2, hue - (1/3))),
+    }
+  }
+
+}

--- a/src/color/hsv2rgb.ts
+++ b/src/color/hsv2rgb.ts
@@ -1,0 +1,35 @@
+import { HSV, RGB } from "../../types";
+
+export function hsv2rgb (hsv: HSV): RGB {
+    const { h, s, v} = hsv;
+
+    if (s === 0) {
+        return { r: v * 255, g: v * 255, b: v * 255}
+    }
+
+
+    let H = h * 6; 
+    if (H === 6) H = 0; 
+
+    const I = Math.floor(H);
+
+    const v1 = v * ( 1 - s);
+    const v2 = v * ( 1 - s * (H - I))
+    const v3 = v * ( 1 - s * (1 - (H - I)))
+
+    let R, G, B; 
+
+    if (I === 0) { R = v; G = v3; B = v1; }
+    else if (I === 1) { R = v2; G = v; B = v1; }
+    else if (I === 2) { R = v1; G = v; B = v3; }
+    else if (I === 3) { R = v1; G = v2; B = v; }
+    else if (I === 4) { R = v3; G = v1; B = v; }    
+    else { R = v; G = v1; B = v2; }
+
+
+    return {
+        r: Math.round(R * 255), 
+        g: Math.round(G * 255), 
+        b: Math.round(B * 255), 
+    }
+}

--- a/src/color/hue2rgb.ts
+++ b/src/color/hue2rgb.ts
@@ -1,0 +1,11 @@
+export function hue2rgb(v1: number, v2: number, hue: number): number {
+
+    if (hue < 0) hue += 1; 
+    if (hue > 1) hue -= 1; 
+
+    if ((6 * hue) < 1) return v1 + (v2 - v1) * 6 * hue 
+    if ((2 * hue) < 1) return v2
+    if ((3 * hue) < 2) return v1 + (v2 - v1) * 6 * ( (2/3) - hue)
+
+    return v1; 
+}

--- a/src/color/index.ts
+++ b/src/color/index.ts
@@ -1,5 +1,5 @@
 import { rgb2hsv } from "./rgb2hsv"
-import { RGB, CMY, LAB, XYZ } from "../../types";
+import { RGB, CMY, LAB, XYZ, HSL, HSV } from "../../types";
 import { rgb2cmy } from "./rgb2cmy";
 import { cmy2rgb } from "./cmy2rgb";
 import { adobe2xyz } from "./adobe2xyz";
@@ -13,6 +13,9 @@ import { xyz2adobe } from "./xyz2adobe";
 import { xyz2lab } from "./xyz2lab";
 import { xyz2rgb } from "./xyz2rgb";
 import { name } from './name';
+import { hsl2rgb } from "./hsl2rgb";
+import { hsv2rgb } from "./hsv2rgb";
+import { rgb2hsl } from "./rgb2hsl";
 
 export {
     name,
@@ -129,6 +132,14 @@ export default class Color {
         }
     }
 
+    get hsl(): Color|undefined {
+        switch (this.data.type) {
+        case 'rgb':
+            const { h, s, l} = rgb2hsl(this.data as RGB);
+            return hsl(h, s, l, this.data.alpha);
+        }
+    }
+
     get cmy(): Color| undefined {
 
         switch(this.data.type) {
@@ -178,7 +189,13 @@ export default class Color {
             return rgb(value.r, value.g, value.b, this.data.alpha);        
         case 'xyz':
             value = xyz2rgb(this.data as XYZ);
-            return rgb(value.r, value.g, value.b, this.data.alpha);                                
+            return rgb(value.r, value.g, value.b, this.data.alpha);
+        case 'hsl':
+            value = hsl2rgb(this.data as HSL);
+            return rgb(value.r, value.g, value.b, this.data.alpha);            
+        case 'hsv':
+            value = hsv2rgb(this.data as HSV);
+            return rgb(value.r, value.g, value.b, this.data.alpha);
         }
     }
 

--- a/src/color/rgb2cmy.ts
+++ b/src/color/rgb2cmy.ts
@@ -1,16 +1,8 @@
-import { ColorListType, RGB, CMY } from "../../types";
+import { RGB, CMY } from "../../types";
 
-export function rgb2cmy(...arg: ColorListType | [RGB]) : CMY {
-  let r:number = 0;
-  let g:number = arg[1] || 0;
-  let b:number = arg[2] || 0;
-  if (arg.length === 1) {
-    r = arg[0].r;
-    g = arg[0].g;
-    b = arg[0].b;
-  } else {
-    r = arg[0];
-  }
+export function rgb2cmy(rgb: RGB) : CMY {
+  const { r, g, b} = rgb; 
+
   return {
     c: 1 - (Math.max(0, Math.min(255, Math.round(r))) / 255),
     m: 1 - (Math.max(0, Math.min(255, Math.round(g))) / 255),

--- a/src/color/rgb2hsl.ts
+++ b/src/color/rgb2hsl.ts
@@ -1,0 +1,55 @@
+import { RGB, HSL } from "../../types";
+
+
+export function rgb2hsl(rgb: RGB): HSL {
+
+
+  const R = ( rgb.r / 255 )
+  const G = ( rgb.g / 255 )
+  const B = ( rgb.b / 255 )
+
+  const min = Math.min(R, G, B);
+  const max = Math.max(R, G, B);
+  const dt = max - min;
+
+  const lightness = (max + min) / 2; 
+
+  if ( dt == 0 ){
+    return {
+      h: 0,
+      s: 0,
+      l: lightness
+    }
+  } else {
+
+    let hue = 0, s = 0;
+
+    if ( lightness < 0.5 ) {
+      s = dt / ( min + max )
+    } else {
+      s = dt / ( 2 - max - min )
+    } 
+
+    const dR = (((max - R) / 6) + (dt/2) ) / dt
+    const dG = (((max - G) / 6) + (dt/2) ) / dt
+    const dB = (((max - B) / 6) + (dt/2) ) / dt
+
+    if ( R == max ) {
+      hue = dB - dG
+    } else if ( G == max ) {
+      hue = (1/3) + dR - dG
+    } else if (B == max ) {
+      hue = (2/3) + dG - dR
+    }
+
+    if (hue < 0) hue += 1; 
+    if (hue > 1) hue -= 1; 
+
+    return {
+      h: hue,
+      s,
+      l: lightness
+    }
+  }
+
+}

--- a/src/color/rgb2hsv.ts
+++ b/src/color/rgb2hsv.ts
@@ -1,47 +1,45 @@
-import { ColorListType, RGB, HSV } from "../../types";
+import { RGB, HSV } from "../../types";
 
-export function rgb2hsv(...arg: ColorListType | [RGB]): HSV {
-  if (arg.length === 1) {
-    var { r, g, b } = arg[0];
-  } else {
-    var [r, g, b] = arg;
-  }
+export function rgb2hsv(rgb: RGB): HSV {
 
-  const rAbs = r / 255;
-  const gAbs = g / 255;
-  const bAbs = b / 255;
+  const { r, g, b } = rgb;
 
-  const max = Math.max(rAbs, gAbs, bAbs);
-  const min = Math.min(rAbs, gAbs, bAbs);
+  const R = r / 255;
+  const G = g / 255;
+  const B = b / 255;
+
+  const max = Math.max(R, G, B);
+  const min = Math.min(R, G, B);
   const delta = max - min;
 
-  if (delta === 0) {
+  const V = max
+
+  if (delta === 0) {      // gray 
     return {
       h: 0,
       s: 0,
-      v: 0,
+      v: V,
     };
   }
 
-  let h = 0;
-  const s = delta / max;
-  const v = max;
 
-  if (rAbs === max) {
-    h = ((gAbs - bAbs) / delta) * 60;
-  } else if (gAbs === max) {
-    h = ((bAbs - rAbs) / delta + 2) * 60;
-  } else if (bAbs === max) {
-    h = ((rAbs - gAbs) / delta + 4) * 60;
-  }
+  const S = delta / max; 
+  let H = 0; 
 
-  if (h < 0) {
-    h += 360;
-  }
+  const delR = ((( max - R ) / 6 ) + (delta / 2) ) / delta
+  const delG = ((( max - G ) / 6 ) + (delta / 2) ) / delta
+  const delB = ((( max - B ) / 6 ) + (delta / 2) ) / delta
+
+  if      ( R == max ) H = delB - delG
+  else if ( G == max ) H = ( 1 / 3 ) + delR - delB
+  else if ( B == max ) H = ( 2 / 3 ) + delG - delR
+
+  if ( H < 0 ) H += 1
+  if ( H > 1 ) H -= 1
 
   return {
-    h,
-    s,
-    v,
+    h: H,
+    s: S,
+    v: V,
   };
 }

--- a/test/color/hsl2rgb.ts
+++ b/test/color/hsl2rgb.ts
@@ -1,0 +1,9 @@
+
+import { hsl2rgb } from "../../src/color/hsl2rgb";
+
+test("test hsl2rgb - convert hsl to rgb", () => {
+
+    const rgb = hsl2rgb({ h: 0.6598639455782311, s: 1, l: 0.5196078431372549 });
+
+    expect(rgb).toEqual({ r: 10, g: 20, b: 255 });
+});  

--- a/test/color/hsv2rgb.ts
+++ b/test/color/hsv2rgb.ts
@@ -1,0 +1,8 @@
+import { hsv2rgb } from "../../src/color/hsv2rgb";
+
+test("test hsv2rgb - convert hsv to rgb", () => {
+
+    const rgb = hsv2rgb({ h: 0.6598639455782311, s: 0.9607843137254902, v: 1 });  
+
+    expect(rgb).toEqual({ r: 10, g: 20, b: 255 });
+});  

--- a/test/color/parse.ts
+++ b/test/color/parse.ts
@@ -1,5 +1,5 @@
 import { name } from "../../src/color/name";
-import { parse, rgb } from "../../src/color";
+import { parse } from "../../src/color";
 
 
 test("test parse - rgb color string", () => {
@@ -14,6 +14,13 @@ test("test parse - rgb color", () => {
     const rgb = parse('rgba(255, 255, 255, 0)');
 
     expect(rgb.data).toEqual({ type: 'rgb', r: 255, g: 255, b: 255, alpha: 0 });
+});  
+
+test("test parse - hsv color", () => {
+
+    const hsv = parse('hsv(0.5, 0.1, 0.1, 0)');
+
+    expect(hsv.data).toEqual({ type: 'hsv', h: 0.5, s: 0.1, v: 0.1, alpha: 0 });
 });  
 
 test("test parse - hsl color", () => {

--- a/test/color/rgb2hsl.ts
+++ b/test/color/rgb2hsl.ts
@@ -1,0 +1,8 @@
+import { rgb2hsl } from "../../src/color/rgb2hsl";
+
+test("test rgb2hsl - convert rgb to hsl", () => {
+
+    const hsl = rgb2hsl({ r: 10, g: 20, b: 255 });
+
+    expect(hsl).toEqual({ h: 0.6598639455782311, s: 1, l: 0.5196078431372549 });
+});  

--- a/test/color/rgb2hsv.ts
+++ b/test/color/rgb2hsv.ts
@@ -1,0 +1,8 @@
+import { rgb2hsv } from "../../src/color";
+
+test("test rgb2hsv - convert rgb to hsv", () => {
+
+    const hsv = rgb2hsv({ r: 10, g: 20, b: 255 });
+
+    expect(hsv).toEqual({ h: 0.6598639455782311, s: 0.9607843137254902, v: 1 });
+});  

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,37 +1,37 @@
-
-export type ColorListType = [number, number, number];
-export type CMYKColorListType = [number, number, number, number];
-
+// r, g, b : 0 ~ 255 
 export interface RGB {
   r: number;
   g: number;
   b: number;
 }
 
+// h, s, v : 0.0 ~ 1.0 
 export interface HSV {
   h: number;
   s: number;
   v: number;
 }
 
+// h, s, l : 0.0 ~ 1.0
+export interface HSL {
+  h: number;
+  s: number;
+  l: number;
+}
+
+// c,m,y : 0.0 ~ 1.0
 export interface CMY {
   c: number;
   m: number;
   y: number;
 }
 
+// c,m,y,k : 0.0 ~ 1.0
 export interface CMYK {
   c: number;
   m: number;
   y: number;
   k: number;
-}
-
-
-export interface RGB {
-  r: number; 
-  g: number; 
-  b: number; 
 }
 
 /**
@@ -55,32 +55,4 @@ export interface Yxy {
   Y: number,
   x: number,
   y: number
-}
-
-
-
-export interface XYZFactory extends Function {
-  (color: XYZ): XYZ;
-
-  (x: number, y: number, z: number): XYZ;
-
-  (v: Array<number>): XYZ;
-
-  (v: Yxy): XYZ;
-
-  fromYxy: (src: Yxy) => XYZ
-  fromArray: (arr: number[], startIndex?: number) => XYZ
-  fromNumber: (x: number, y: number, z: number) => XYZ
-}
-
-export interface YxyFactory extends Function {
-  (color: Yxy): Yxy;
-
-  (Y: number, x: number, y: number): Yxy;
-
-  (v: Array<number>): Yxy;
-
-  fromXYZ: (src: XYZ) => Yxy
-  fromArray: (arr: number[], startIndex?: number) => Yxy
-  fromNumber: (Y: number, x: number, y: number) => Yxy
 }


### PR DESCRIPTION
컬러함수에 대한 리팩토링을 진행했습니다. 

몇가지 규칙이 추가 되었습니다. 

1. 컬러 변환 함수는  객체를 매개변수로 받고 객체를 리턴합니다.   이렇게 하는 이유는 alpha 값 을 사전에 핸들링 할 수 있도록 하기 위함입니다. 
ex)  rgb2hsl({ r, g, b}) => { h, s, l }   

2. 매개변수 활용을 위해 색상별 유틸리티 함수를 만듭니다. 
ex) rgb(r, g, b) => { r, g, b}      개별 색상 함수로 특정 색상 객체를 만드는 방식입니다.  
ex)  rgb2hsl(rgb(r, g, b)) => { h, s, l }     

3. 컬러 문자열에서 색상 변경 하는 것은 parse 함수를 실행합니다. 
ex)  parse('rgb(255, 255, 0)')  => rgb(255, 255, 0) => { r: 255, g: 255, b: 0 }   형태로 변환이 됩니다.  

parse 는 이미 정해진 function (rgb, hsl 등) 을 가지고 동적 함수를 사용해서 바로 실행하는 방법으로 구현 되어 있습니다. 
즉, 특정한 파싱 구문을 사용하지 않고 js 에서 지원하는 네이티브 방식으로 파싱을 구현한 상태입니다. 참고하세요. 
